### PR TITLE
Display operation hours from 24 to am pm

### DIFF
--- a/src/components/account/HoursOfOperationStat.jsx
+++ b/src/components/account/HoursOfOperationStat.jsx
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import EditHoursModal from "./EditHoursModal";
+import { convertIntegerToAMPM } from "../../lib/timeSlotUtil.js";
 
 const HoursOfOperationStat = ({
   valetData,
@@ -7,11 +8,18 @@ const HoursOfOperationStat = ({
   setClosingHour,
   handleHoursUpdate,
 }) => {
+  const formattedOpeningHour = convertIntegerToAMPM(
+    valetData?.operation_hours.split("-")[0]
+  );
+  const formattedClosingHour = convertIntegerToAMPM(
+    valetData?.operation_hours.split("-")[1]
+  );
+
   return (
     <div className="stats shadow w-[50%]">
       <div className="stat">
         <div className="stat-title">Hours of Operation</div>
-        <div className="stat-value">{valetData?.operation_hours}</div>
+        <div className="stat-value">{`${formattedOpeningHour} - ${formattedClosingHour}`}</div>
         <button
           className="btn btn-ghost text-blue-500"
           onClick={() => document.getElementById("editHoursModal").showModal()}

--- a/src/lib/timeSlotUtil.js
+++ b/src/lib/timeSlotUtil.js
@@ -28,13 +28,13 @@ export const convertTime = (number) => {
 
 export const convertIntegerToAMPM = (hour) => {
   if (hour === 0) {
-    return "12AM";
+    return "12 AM";
   } else if (hour === 12) {
-    return "12PM";
+    return "12 PM";
   } else if (hour < 12) {
-    return `${hour}AM`;
+    return `${hour} AM`;
   } else {
-    return `${hour - 12}PM`;
+    return `${hour - 12} PM`;
   }
 };
 

--- a/src/lib/timeSlotUtil.js
+++ b/src/lib/timeSlotUtil.js
@@ -26,6 +26,18 @@ export const convertTime = (number) => {
   }
 };
 
+export const convertIntegerToAMPM = (hour) => {
+  if (hour === 0) {
+    return "12AM";
+  } else if (hour === 12) {
+    return "12PM";
+  } else if (hour < 12) {
+    return `${hour}AM`;
+  } else {
+    return `${hour - 12}PM`;
+  }
+};
+
 export const convertDBTime = (time) => {
   if (time === "12:00 PM") return 12;
 


### PR DESCRIPTION
Minor aesthetic changes to display operation hours in the admins analytics dashboard.

-  the long hand hour as in: 1:00AM was too long for the stats card
- so decided to write own function to just change it to 1AM, short hand style.